### PR TITLE
Correction of payout addresses, and coordinator

### DIFF
--- a/settings/dingo.json
+++ b/settings/dingo.json
@@ -7,13 +7,12 @@
     "DRkCnvWDPQDXRCVLmgWTJTvRcSju6yJwzx",
     "DMb82VSRGA6vEWkwFKdutSGs7xipsBhCJ4",
     "DJ2HbxgHaktGtsrwFCzoZfts4i4bAha3oN",
-    "DHBj52iiQZkgPYK59PzXLEDM2gmRgTkvjU",
+    "DTMmZmiYF6zGZnrzfs1cjYqbjgv5xnxfSZ",
     "DL8jBtJmobLUQ2NaiE1kHwUCxSCTDvexxX",
     "D7Zrb9PLkvXBGKvZqY3SPqF8VB5LsWYpPz",
-    "DRkCnvWDPQDXRCVLmgWTJTvRcSju6yJwzx",
     "DMjyNAsAPXNYynTJ7ggSJRPErPzsMNCwQp",
     "DPp332rgD4U1A6xZuC6f5godnQFrRdXaLL",
-    "DHBj52iiQZkgPYK59PzXLEDM2gmRgTkvjU"
+    "DH1BHP2dPaACy8HUaUVZaGGUYsKnxqcPYa"
   ],
   "syncDelayThreshold": 15
 }

--- a/settings/public.json
+++ b/settings/public.json
@@ -13,11 +13,6 @@
       "walletAddress": "EVuch1fgvSNNGzufCApt9GNn6aLjE79u772Ft6iNESoE"
     },
     {
-      "hostname": "n7.dingocoin.org",
-      "port": 8443,
-      "walletAddress": "8HhQmcw8gBnqQEzcwdWHneMCGJKgvn8gkN24CZk6EcSX"
-    },
-    {
       "hostname": "n8.dingocoin.org",
       "port": 8443,
       "walletAddress": "7mbSCfTimaNRwm4UNqUHv7qLHsJMxbfCfPU3YzagD25v"
@@ -33,5 +28,5 @@
       "walletAddress": "BdDJ2mqfTkUww7j2UQywo3nkvzRE8JYVdXTUaXsSRUSc"
     }
   ],
-  "payoutCoordinator": 5
+  "payoutCoordinator": 3
 }

--- a/settings/solana.json
+++ b/settings/solana.json
@@ -5,7 +5,6 @@
   "multisigSigners": [
     "4AVbZEFFoiXrAqfzw3pbQJ1kEWgYBFBgEFFAkre76Pd8",
     "EVuch1fgvSNNGzufCApt9GNn6aLjE79u772Ft6iNESoE",
-    "8HhQmcw8gBnqQEzcwdWHneMCGJKgvn8gkN24CZk6EcSX",
     "7mbSCfTimaNRwm4UNqUHv7qLHsJMxbfCfPU3YzagD25v",
     "9rJiB1NevdpbDjFC96A86b4KAP2X76vzSYiETf7ixkA3",
     "BdDJ2mqfTkUww7j2UQywo3nkvzRE8JYVdXTUaXsSRUSc"


### PR DESCRIPTION
# July correction of payout addresses, and removal of node 7, and reassigning of payoutCoordinator

July correction of payout addresses.
updated dingo.json to match the manual change previously made. Other changes manually adjusted.

n7.dingocoin.org was removed from public.json, and the corresponding multisig signer public key/address had also been removed. Note: While the multisig does not require every signature, the authority node code requires EVERY node to agree. 

Correct and adjust payoutCoordinator.
Since the removal of node 7 the payoutCoordinator should have been moved down from 5 (of 0 to 5) to 4, but the role is also being reassigned to node 9, which is 3 (when counting from zero).